### PR TITLE
Fix IME composition bug on Firefox

### DIFF
--- a/lib/commands/collapse-math-cmd.ts
+++ b/lib/commands/collapse-math-cmd.ts
@@ -47,14 +47,56 @@ export function collapseMathCmd(
 			// set outer selection to be outside of the nodeview
 			let targetPos: number = (dir > 0) ? outerTo : outerFrom;
 
+			/**
+			 * On Firefox, the cursor is invisible and the first IME composition will be broken.
+			 * Probably because the cursor is at the start/end of the outer node, not inside it.
+			 * Should move the selection one step further for exiting block math nodes.
+			 * On Chrome/Safari it works fine, but maybe we should do this for all browsers.
+			 * Doesn't seem to have any negative effects.
+			 */
+			if (innerState.doc.type.name === "math_display") {
+				targetPos += dir;
+			}
+
+			/**
+			 * https://forums.zotero.org/discussion/100416/note-editor-cant-continue-to-use-input-method-editor-after-entering-inline-math
+			 * https://forums.zotero.org/discussion/101947/crash-when-writing-math-together-with-chinese-input-%E4%B8%80%E8%B5%B7%E5%86%99%E6%95%B0%E5%AD%A6%E5%85%AC%E5%BC%8F%E5%92%8C%E4%B8%AD%E6%96%87%E6%97%B6%E5%B4%A9%E6%BA%83
+			 * https://forums.zotero.org/discussion/118104/inability-to-input-chinese-characters-after-latex-formula-rendering-in-notes
+			 * 
+			 * Fix for Firefox bug with exiting math nodes with arrow keys:
+			 * Step 1:
+			 * Move the focus out before the selection change triggers MathView#deselectNode
+			 * (which will destroy the inner view)
+			 * Otherwise, the IME composition will be broken.
+			 * In browser, the IME composition falls back to the system input target.
+			 * In Zotero, the IME composition loses the target and freezes/quits Zotero.
+			 * Should do this for all browsers, as anyway we need to move the focus out.
+			 */
+			if (!outerView.hasFocus()) outerView.focus();
+
 			outerView.dispatch(
 				outerState.tr.setSelection(
 					TextSelection.create(outerState.doc, targetPos)
 				)
 			);
 
-			// must return focus to the outer view, otherwise no cursor will appear
-			outerView.focus();
+			/**
+			 * Fix for Firefox bug with exiting math nodes with arrow keys:
+			 * Step 2:
+			 * Now you can input with a non-latin IME,
+			 * but the composition is converted to a normal text.
+			 * To fix this, we need to move the focus to some specific element, e.g. a button,
+			 * and then move it back to the outer view.
+			 * (No idea why this works, but a div doesn't work.)
+			 * Only Firefox needs this, so we check the user agent.
+			 */
+			if (window.navigator.userAgent.includes("Firefox")) {
+				const tmpBtn = document.createElement("button");
+				document.body.append(tmpBtn);
+				tmpBtn.focus();
+				tmpBtn.remove();
+				outerView.focus();
+			}
 		}
 		
 		return true;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:check": "tsc --project tsconfig.build.json",
     "build:lib": "vite --config vite.config.lib.ts build",
     "build:site": "npm run build:check && vite build",
-    "build": "npm run build:Check && npm run build:lib",
+    "build": "npm run build:check && npm run build:lib",
     "dev": "vite",
     "preview": "vite preview",
     "prepare": "npm run build:lib"


### PR DESCRIPTION
See also https://forums.zotero.org/discussion/100416/note-editor-cant-continue-to-use-input-method-editor-after-entering-inline-math
See also https://forums.zotero.org/discussion/101947/crash-when-writing-math-together-with-chinese-input-%E4%B8%80%E8%B5%B7%E5%86%99%E6%95%B0%E5%AD%A6%E5%85%AC%E5%BC%8F%E5%92%8C%E4%B8%AD%E6%96%87%E6%97%B6%E5%B4%A9%E6%BA%83
See also https://forums.zotero.org/discussion/118104/inability-to-input-chinese-characters-after-latex-formula-rendering-in-notes